### PR TITLE
Rework transaction function (closes #8, closes #9)

### DIFF
--- a/src/transaction/index.ts
+++ b/src/transaction/index.ts
@@ -187,9 +187,9 @@ export type TransactionReadFunction<ReadResult> = (
 /**
  * The transaction body function type.
  */
-export type TransactionWriteFunction<ReadResult> = (
+export type TransactionWriteFunction<ReadResult, WriteResult> = (
   api: TransactionWrite<ReadResult>
-) => any
+) => Promise<WriteResult>
 
 /**
  * The function allows performing transactions. It accepts two functions.
@@ -217,10 +217,10 @@ export type TransactionWriteFunction<ReadResult> = (
  *   transaction write API with the data returned by the read function
  * @returns Promise that is resolved when transaction is closed
  */
-export function transaction<ReadResult>(
+export function transaction<ReadResult, WriteResult>(
   readFunction: TransactionReadFunction<ReadResult>,
-  writeFunction: TransactionWriteFunction<ReadResult>
-): Promise<any> {
+  writeFunction: TransactionWriteFunction<ReadResult, WriteResult>
+): Promise<WriteResult> {
   return firestore().runTransaction(t => {
     async function get<Model>(
       collectionOrRef: Collection<Model> | Ref<Model>,

--- a/src/transaction/test.ts
+++ b/src/transaction/test.ts
@@ -22,13 +22,15 @@ describe('transaction', () => {
         } = await get(counter)
         return count
       },
-      ({ data: count, set, update }) => {
-        const payload = { count: count + 1 }
+      async ({ data: count, set, update }) => {
+        const newCount = count + 1
+        const payload = { count: newCount }
         if (useUpdate) {
-          return update(counter, payload)
+          await update(counter, payload)
         } else {
-          return set(counter, payload)
+          await set(counter, payload)
         }
+        return newCount
       }
     )
 
@@ -41,6 +43,18 @@ describe('transaction', () => {
       data: { count }
     } = await get(counter)
     assert(count === 3)
+  })
+
+  it('returns the value from the write function', async () => {
+    const id = nanoid()
+    const counter = ref(counters, id)
+    await set(counter, { count: 0 })
+    const results = await Promise.all([
+      plusOne(counter),
+      plusOne(counter),
+      plusOne(counter)
+    ])
+    assert.deepEqual(results.sort(), [1, 2, 3])
   })
 
   it('allows updating', async () => {


### PR DESCRIPTION
- Make the transaction function receive two functions, one that would allow reading and another that would allow writing. It will make it impossible to perform reads after writes, which would throw an exception as it's a Firebase limitation.
- Define the transaction function result type.