### PR TITLE
Remove peer dependencies (closes #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ The library is available as an [npm package](https://www.npmjs.com/package/types
 To install Typesaurus run:
 
 ```sh
-npm install typesaurus @google-cloud/firestore firebase firebase-admin --save
-# or with yarn
-yarn add typesaurus @google-cloud/firestore firebase firebase-admin
+npm install typesaurus --save
+# Or using yarn:
+yarn add typesaurus
 ```
 
-_Note that Typesaurus requires `firebase` package to work in the web environment and `@google-cloud/firestore` with `firebase-admin` to work in Node.js. These packages are listed in the peer dependencies and won't install automatically along with the Typesaurus package._
+_Note that Typesaurus requires `firebase` package to work in the web environment and `firebase-admin` to work in Node.js. These packages aren't listed as dependencies,
+so that they won't install automatically along with the Typesaurus package._
 
 ## Get started
 

--- a/package.json
+++ b/package.json
@@ -40,10 +40,5 @@
     "typedoc": "^0.15.0",
     "typescript": "^3.7.4",
     "webpack": "^4.37.0"
-  },
-  "peerDependencies": {
-    "@google-cloud/firestore": ">=2.6.0",
-    "firebase": ">=7.5.0",
-    "firebase-admin": ">=8.8.0"
   }
 }


### PR DESCRIPTION
So that npm won't show useless unavoidable warnings when Typesaurus is used only in the web or Node.js environment.