### PR TITLE
Fix union/remove update on an array of references

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -8,7 +8,7 @@ import { UpdateValue } from '../value'
  *
  * @param data - the data to convert
  */
-export function unwrapData(data: any) {
+export function unwrapData(data: any): any {
   if (data && typeof data === 'object') {
     if (data.__type__ === 'ref') {
       return refToFirestoreDocument(data as Ref<any>)
@@ -20,9 +20,9 @@ export function unwrapData(data: any) {
         case 'increment':
           return consts().FieldValue.increment(fieldValue.number)
         case 'arrayUnion':
-          return consts().FieldValue.arrayUnion(...fieldValue.values)
+          return consts().FieldValue.arrayUnion(...unwrapData(fieldValue.values))
         case 'arrayRemove':
-          return consts().FieldValue.arrayRemove(...fieldValue.values)
+          return consts().FieldValue.arrayRemove(...unwrapData(fieldValue.values))
         case 'serverDate':
           return consts().FieldValue.serverTimestamp()
       }


### PR DESCRIPTION
Updating an array of document references resulted in the following error:

> INVALID_ARGUMENT: Property collection contains an invalid nested entity.

This was because the `unwrapData` function did not properly unwrap values inside `UpdateValue` objects, and directly passed `Ref` objects to Firestore SDK's `FieldValue.arrayUnion` / `FieldValue.arrayRemove`.