### PR TITLE
CollectionEntity should use the first generic type of Subcollection

### DIFF
--- a/src/group/index.ts
+++ b/src/group/index.ts
@@ -9,7 +9,7 @@ export interface CollectionGroup<_Model> {
   path: string
 }
 
-type CollectionEntity<Model> = Collection<Model> | Subcollection<any, Model>
+type CollectionEntity<Model> = Collection<Model> | Subcollection<Model, any>
 
 function group<A>(
   path: string,


### PR DESCRIPTION
![スクリーンショット 2020-04-14 23 37 54](https://user-images.githubusercontent.com/14799020/79237355-07950180-7ea9-11ea-9569-4086bffab463.png)

(writing in English is so tough for me, forgive me if it doesn't make sense)

 I assume that CollectionEntity should use the first generic type in Subcollection<Child, Parent> for its `Model`, not the second one.  
The second one is parental model, and using  parental model type breaks type assertion of the query for collection groups like the above screenshot(the code in the screenshot is from the [exampe code](https://github.com/kossnocorp/typesaurus/blob/master/src/group/index.ts#L33-L48) in this repository). 

`allPosts` in the screenshot is inferred `CollectionGroup<User | Post>` but I think it should have been `CollectionGroup<Post>`

Thanks for making great library.