### PR TITLE
Allows querying nested subcollection groups

### DIFF
--- a/src/group/index.ts
+++ b/src/group/index.ts
@@ -1,5 +1,5 @@
 import { Collection } from '../collection'
-import { Subcollection } from '../subcollection'
+import { Subcollection, NestedSubcollection } from '../subcollection'
 
 /**
  * The collection group type. It contains the collection name.
@@ -9,7 +9,10 @@ export interface CollectionGroup<_Model> {
   path: string
 }
 
-type CollectionEntity<Model> = Collection<Model> | Subcollection<Model, any>
+type CollectionEntity<Model> =
+  | Collection<Model>
+  | Subcollection<Model, any>
+  | NestedSubcollection<Model, Model, any>
 
 function group<A>(
   path: string,

--- a/src/query/test.ts
+++ b/src/query/test.ts
@@ -270,6 +270,39 @@ describe('query', () => {
     ])
   })
 
+  it('allows querying nested subcollection groups', async () => {
+    const contactMessages = subcollection<Message, Contact>(
+      'contactMessages',
+      contacts
+    )
+    type Post = {
+      ownerId: string
+      title: string
+    }
+    const nestedPost = subcollection<Post, Message, Contact>(
+      'posts',
+      contactMessages
+    )
+
+    const ownerId = nanoid()
+    const messageId = nanoid()
+    const nestedPostRef = nestedPost([messageId, ownerId])
+    await add(nestedPostRef, {
+      ownerId,
+      title: 'Hello'
+    })
+    await add(nestedPostRef, {
+      ownerId,
+      title: 'Hello, again!'
+    })
+    const allPosts = group('posts', [nestedPost])
+    const posts = await query(allPosts, [where('ownerId', '==', ownerId)])
+    assert.deepEqual(posts.map((m) => m.data.title).sort(), [
+      'Hello',
+      'Hello, again!'
+    ])
+  })
+
   describe('ordering', () => {
     it('allows ordering', async () => {
       const docs = await query(contacts, [


### PR DESCRIPTION
Hi!

I want to use nested subcollection in `query()`.

```
const allPosts = group('posts', [nestedPost]) // nestedPost is NestedSubcollection
const posts = await query(allPosts, [])
```