### PR TITLE
Add feature to get changeset of each snapshot of onAll and onQuery

### DIFF
--- a/src/onAll/index.ts
+++ b/src/onAll/index.ts
@@ -57,22 +57,30 @@ export default function onAll<Model>(
           a.getDocMeta(snap)
         )
       )
-      const docChanges = () => firestoreSnap.docChanges().map(change => ({
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: docs[change.type === 'removed' ? change.oldIndex : change.newIndex] ||
-          // If change.type indicates 'removed', sometimes(not all the time) `docs` does not
-          // contain the removed document. In that case, we'll restore it from `change.doc`:
-          doc(
-            collection.__type__ === 'collectionGroup'
-              ? pathToRef(change.doc.ref.path)
-              : ref(collection, change.doc.id),
-            wrapData(a, change.doc.data()) as Model,
-            a.getDocMeta(change.doc)
-          )
-      }))
-      onResult(docs, { docChanges, size: firestoreSnap.size, empty: firestoreSnap.empty })
+      const changes = () =>
+        firestoreSnap.docChanges().map((change) => ({
+          type: change.type,
+          oldIndex: change.oldIndex,
+          newIndex: change.newIndex,
+          doc:
+            docs[
+              change.type === 'removed' ? change.oldIndex : change.newIndex
+            ] ||
+            // If change.type indicates 'removed', sometimes(not all the time) `docs` does not
+            // contain the removed document. In that case, we'll restore it from `change.doc`:
+            doc(
+              collection.__type__ === 'collectionGroup'
+                ? pathToRef(change.doc.ref.path)
+                : ref(collection, change.doc.id),
+              wrapData(a, change.doc.data()) as Model,
+              a.getDocMeta(change.doc)
+            )
+        }))
+      onResult(docs, {
+        changes,
+        size: firestoreSnap.size,
+        empty: firestoreSnap.empty
+      })
     }, onError)
   })
 

--- a/src/onAll/index.ts
+++ b/src/onAll/index.ts
@@ -4,6 +4,7 @@ import { wrapData } from '../data'
 import { doc, Doc } from '../doc'
 import { CollectionGroup } from '../group'
 import { pathToRef, ref } from '../ref'
+import { SnapshotInfo } from '../snapshot'
 
 /**
  * Subscribes to all documents in a collection.
@@ -31,7 +32,7 @@ import { pathToRef, ref } from '../ref'
  */
 export default function onAll<Model>(
   collection: Collection<Model> | CollectionGroup<Model>,
-  onResult: (docs: Doc<Model>[]) => any,
+  onResult: (docs: Doc<Model>[], info: SnapshotInfo<Model>) => any,
   onError?: (error: Error) => any
 ): () => void {
   let unsubCalled = false
@@ -46,8 +47,8 @@ export default function onAll<Model>(
     firebaseUnsub = (collection.__type__ === 'collectionGroup'
       ? a.firestore.collectionGroup(collection.path)
       : a.firestore.collection(collection.path)
-    ).onSnapshot((firebaseSnap) => {
-      const docs = firebaseSnap.docs.map((snap) =>
+    ).onSnapshot((firestoreSnap) => {
+      const docs = firestoreSnap.docs.map((snap) =>
         doc<Model>(
           collection.__type__ === 'collectionGroup'
             ? pathToRef(snap.ref.path)
@@ -56,7 +57,22 @@ export default function onAll<Model>(
           a.getDocMeta(snap)
         )
       )
-      onResult(docs)
+      const docChanges = () => firestoreSnap.docChanges().map(change => ({
+        type: change.type,
+        oldIndex: change.oldIndex,
+        newIndex: change.newIndex,
+        doc: docs[change.type === 'removed' ? change.oldIndex : change.newIndex] ||
+          // If change.type indicates 'removed', sometimes(not all the time) `docs` does not
+          // contain the removed document. In that case, we'll restore it from `change.doc`:
+          doc(
+            collection.__type__ === 'collectionGroup'
+              ? pathToRef(change.doc.ref.path)
+              : ref(collection, change.doc.id),
+            wrapData(a, change.doc.data()) as Model,
+            a.getDocMeta(change.doc)
+          )
+      }))
+      onResult(docs, { docChanges, size: firestoreSnap.size, empty: firestoreSnap.empty })
     }, onError)
   })
 

--- a/src/onAll/test.ts
+++ b/src/onAll/test.ts
@@ -141,10 +141,10 @@ describe('onAll', () => {
 
   describe('empty', () => {
     it('should notify with values all indicate empty', (done) => {
-      off = onAll(collection('void'), (docs, { docChanges, empty }) => {
+      off = onAll(collection('void'), (docs, { changes, empty }) => {
         expect(empty).toBeTruthy()
         expect(docs).toHaveLength(0)
-        expect(docChanges()).toHaveLength(0)
+        expect(changes()).toHaveLength(0)
         done()
       })
     })
@@ -153,10 +153,10 @@ describe('onAll', () => {
   describe('real-time', () => {
     it('subscribes to updates', (done) => {
       let c = 0
-      off = onAll(books, async (docs, { docChanges }) => {
+      off = onAll(books, async (docs, { changes }) => {
         const titles = docs.map(({ data: { title } }) => title).sort()
-        const changes = docChanges()
-          .map(({ type, doc: { data: { title } }}) => ({ type, title }))
+        const docChanges = changes()
+          .map(({ type, doc: { data: { title } } }) => ({ type, title }))
           .sort((a, b) => a.title.localeCompare(b.title))
 
         switch (++c) {
@@ -166,7 +166,7 @@ describe('onAll', () => {
               'The 22 Immutable Laws of Marketing',
               'The Mom Test'
             ])
-            expect(changes).toEqual([
+            expect(docChanges).toEqual([
               { type: 'added', title: 'Sapiens' },
               { type: 'added', title: 'The 22 Immutable Laws of Marketing' },
               { type: 'added', title: 'The Mom Test' }
@@ -182,8 +182,8 @@ describe('onAll', () => {
               'The 22 Immutable Laws of Marketing',
               'The Mom Test'
             ])
-            expect(changes).toEqual([
-              { type: 'added', title: "Harry Potter and the Sorcerer's Stone" },
+            expect(docChanges).toEqual([
+              { type: 'added', title: "Harry Potter and the Sorcerer's Stone" }
             ])
             done()
         }

--- a/src/onQuery/index.ts
+++ b/src/onQuery/index.ts
@@ -9,6 +9,7 @@ import { LimitQuery } from '../limit'
 import { OrderQuery } from '../order'
 import { pathToRef, ref } from '../ref'
 import { WhereQuery } from '../where'
+import { SnapshotInfo } from '../snapshot'
 
 type FirebaseQuery =
   | FirebaseFirestore.CollectionReference
@@ -56,7 +57,7 @@ export type Query<Model, Key extends keyof Model> =
 export default function onQuery<Model>(
   collection: Collection<Model> | CollectionGroup<Model>,
   queries: Query<Model, keyof Model>[],
-  onResult: (docs: Doc<Model>[]) => any,
+  onResult: (docs: Doc<Model>[], info: SnapshotInfo<Model>) => any,
   onError?: (err: Error) => any
 ): () => void {
   let unsubCalled = false
@@ -152,17 +153,32 @@ export default function onQuery<Model>(
 
       firebaseUnsub = paginatedFirestoreQuery.onSnapshot(
         (firestoreSnap: FirebaseFirestore.QuerySnapshot) => {
-          onResult(
-            firestoreSnap.docs.map((snap) =>
-              doc(
-                collection.__type__ === 'collectionGroup'
-                  ? pathToRef(snap.ref.path)
-                  : ref(collection, snap.id),
-                wrapData(a, snap.data()) as Model,
-                a.getDocMeta(snap)
-              )
+          const docs = firestoreSnap.docs.map((snap) =>
+            doc(
+              collection.__type__ === 'collectionGroup'
+                ? pathToRef(snap.ref.path)
+                : ref(collection, snap.id),
+              wrapData(a, snap.data()) as Model,
+              a.getDocMeta(snap)
             )
           )
+
+          const docChanges = () => firestoreSnap.docChanges().map(change => ({
+            type: change.type,
+            oldIndex: change.oldIndex,
+            newIndex: change.newIndex,
+            doc: docs[change.type === 'removed' ? change.oldIndex : change.newIndex] ||
+              // If change.type indicates 'removed', sometimes(not all the time) `docs` does not
+              // contain the removed document. In that case, we'll restore it from `change.doc`:
+              doc(
+                collection.__type__ === 'collectionGroup'
+                  ? pathToRef(change.doc.ref.path)
+                  : ref(collection, change.doc.id),
+                wrapData(a, change.doc.data()) as Model,
+                a.getDocMeta(change.doc)
+              )
+          }))
+          onResult(docs, { docChanges, size: firestoreSnap.size, empty: firestoreSnap.empty })
         },
         onError
       )

--- a/src/onQuery/index.ts
+++ b/src/onQuery/index.ts
@@ -163,22 +163,30 @@ export default function onQuery<Model>(
             )
           )
 
-          const docChanges = () => firestoreSnap.docChanges().map(change => ({
-            type: change.type,
-            oldIndex: change.oldIndex,
-            newIndex: change.newIndex,
-            doc: docs[change.type === 'removed' ? change.oldIndex : change.newIndex] ||
-              // If change.type indicates 'removed', sometimes(not all the time) `docs` does not
-              // contain the removed document. In that case, we'll restore it from `change.doc`:
-              doc(
-                collection.__type__ === 'collectionGroup'
-                  ? pathToRef(change.doc.ref.path)
-                  : ref(collection, change.doc.id),
-                wrapData(a, change.doc.data()) as Model,
-                a.getDocMeta(change.doc)
-              )
-          }))
-          onResult(docs, { docChanges, size: firestoreSnap.size, empty: firestoreSnap.empty })
+          const changes = () =>
+            firestoreSnap.docChanges().map((change) => ({
+              type: change.type,
+              oldIndex: change.oldIndex,
+              newIndex: change.newIndex,
+              doc:
+                docs[
+                  change.type === 'removed' ? change.oldIndex : change.newIndex
+                ] ||
+                // If change.type indicates 'removed', sometimes(not all the time) `docs` does not
+                // contain the removed document. In that case, we'll restore it from `change.doc`:
+                doc(
+                  collection.__type__ === 'collectionGroup'
+                    ? pathToRef(change.doc.ref.path)
+                    : ref(collection, change.doc.id),
+                  wrapData(a, change.doc.data()) as Model,
+                  a.getDocMeta(change.doc)
+                )
+            }))
+          onResult(docs, {
+            changes,
+            size: firestoreSnap.size,
+            empty: firestoreSnap.empty
+          })
         },
         onError
       )

--- a/src/onQuery/test.ts
+++ b/src/onQuery/test.ts
@@ -775,10 +775,10 @@ describe('onQuery', () => {
       off = onQuery(
         collection<{ ability: string[] }>('penguin'),
         [where('ability', 'array-contains', 'fly')],
-        (docs, { docChanges, empty }) => {
+        (docs, { changes, empty }) => {
           expect(empty).toBeTruthy()
           expect(docs).toHaveLength(0)
-          expect(docChanges()).toHaveLength(0)
+          expect(changes()).toHaveLength(0)
           done()
         }
       )
@@ -803,16 +803,19 @@ describe('onQuery', () => {
           order('year', 'asc', [startAt(1989)]),
           limit(3)
         ],
-        async (docs, { docChanges }) => {
+        async (docs, { changes }) => {
           const names = docs.map(({ data: { name } }) => name).sort()
-          const changes = docChanges()
-            .map(({ type, doc: { data: { name } }}) => ({ type, name }))
+          const docChanges = changes()
+            .map(({ type, doc: { data: { name } } }) => ({ type, name }))
             .sort((a, b) => a.name.localeCompare(b.name))
 
           switch (++c) {
             case 1:
               expect(names).toEqual(['Lesha', 'Tati'])
-              expect(changes).toEqual([{ type: 'added', name: 'Lesha' }, { type: 'added', name: 'Tati' }])
+              expect(docChanges).toEqual([
+                { type: 'added', name: 'Lesha' },
+                { type: 'added', name: 'Tati' }
+              ])
               await set(contacts, theoId, {
                 ownerId,
                 name: 'Theodor',
@@ -822,11 +825,11 @@ describe('onQuery', () => {
               return
             case 2:
               expect(names).toEqual(['Lesha', 'Tati', 'Theodor'])
-              expect(changes).toEqual([{ type: 'added', name: 'Theodor' }])
+              expect(docChanges).toEqual([{ type: 'added', name: 'Theodor' }])
               await remove(contacts, leshaId)
               return
             case 3:
-              expect(changes).toEqual([{ type: 'removed', name: 'Theodor'}])
+              expect(docChanges).toEqual([{ type: 'removed', name: 'Theodor' }])
               done()
           }
         }

--- a/src/snapshot/index.ts
+++ b/src/snapshot/index.ts
@@ -37,7 +37,7 @@ export interface SnapshotInfo<Model> {
    * this is the first snapshot, all documents will be in the list as added
    * changes.
    */
-  docChanges: () => DocChange<Model>[]
+  changes: () => DocChange<Model>[]
 
   /** The number of documents in the QuerySnapshot. */
   readonly size: number

--- a/src/snapshot/index.ts
+++ b/src/snapshot/index.ts
@@ -1,0 +1,47 @@
+import { Doc } from '../doc'
+
+/**
+ * The type of a `DocumentChange` may be 'added', 'removed', or 'modified'.
+ */
+export type DocChangeType = 'added' | 'removed' | 'modified'
+
+export interface DocChange<Model> {
+  /** The type of change ('added', 'modified', or 'removed'). */
+  readonly type: DocChangeType
+
+  /** The document affected by this change. */
+  readonly doc: Doc<Model>
+
+  /**
+   * The index of the changed document in the result set immediately prior to
+   * this `DocumentChange` (i.e. supposing that all prior `DocumentChange` objects
+   * have been applied). Is -1 for 'added' events.
+   */
+  readonly oldIndex: number
+
+  /**
+   * The index of the changed document in the result set immediately after
+   * this `DocumentChange` (i.e. supposing that all prior `DocumentChange`
+   * objects and the current `DocumentChange` object have been applied).
+   * Is -1 for 'removed' events.
+   */
+  readonly newIndex: number
+}
+
+/**
+ * An options object that configures the snapshot contents of `onAll()` and `onQuery()`.
+ */
+export interface SnapshotInfo<Model> {
+  /**
+   * Returns an array of the documents changes since the last snapshot. If
+   * this is the first snapshot, all documents will be in the list as added
+   * changes.
+   */
+  docChanges: () => DocChange<Model>[]
+
+  /** The number of documents in the QuerySnapshot. */
+  readonly size: number
+
+  /** True if there are no documents in the QuerySnapshot. */
+  readonly empty: boolean
+}


### PR DESCRIPTION
For #65 

I combined the option 2 & 3 this time.
To add `options` param(opt#2) felt redundant when I was writing it in the editor.

To secure extendability, I choose to pass an infoset as an object and embed 
a lambda function instead of a changeset object itself, the function enables clients
to retrieve changeset.
```typescript
export default function onQuery<Model>(
  collection: Collection<Model> | CollectionGroup<Model>,
  queries: Query<Model, keyof Model>[],
  onResult: (docs: Doc<Model>[], info: SnapshotInfo<Model>) => any,
  onError?: (err: Error) => any
): () => void {
```

By the way, in the test code, is there any specific reason to use `spy`?
The existent counterpart test code of the patch, there was no message on test
failures but only timeout, due to the usage of `spy`.
I've replaced and rewritten them with `expect`/`to~` series and works well
in my environment.
But if this way would cause your known issues, I'll rewrite again.