### PR TITLE
Allow readonly array in where

### DIFF
--- a/src/where/index.ts
+++ b/src/where/index.ts
@@ -23,7 +23,7 @@ function where<Model, Key extends keyof Model>(
 function where<Model, Key extends keyof Model>(
   field: Key | [Key] | DocId,
   filter: 'in',
-  value: string[]
+  value: string[] | readonly string[]
 ): WhereQuery<Model>
 
 // Basic filter variation


### PR DESCRIPTION
Allows

```ts
const array = ['a', 'b'] as const;
query(doc, [where('key', 'in', array)])
```

Without this PR, an error is throw:
```
No overload matches this call.
  The last overload gave the following error.
    Argument of type 'string' is not assignable to parameter of type '[keyof DbOrder, string | number | symbol, string | number | symbol, string | number | symbol, string | number | symbol, string | number | symbol, string | number | symbol, string | ... 1 more ... | symbol, string | ... 1 more ... | symbol, string | ... 1 more ... | symbol]'.
```