### PR TITLE
Add support for specifying (named) Firestore database ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This change log follows the format documented in [Keep a CHANGELOG].
 [semantic versioning]: http://semver.org/
 [keep a changelog]: http://keepachangelog.com/
 
+## v10.7.1 - 2025-11-28
+
+### Added
+
+- Added `database` option to `Typesaurus.Options` to allow specifying the database ID.
+
 ## v10.7.0 - 2024-04-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typesaurus",
-  "version": "10.7.0",
+  "version": "10.7.1",
   "description": "Type-safe ODM for Firestore",
   "keywords": [
     "Firebase",

--- a/src/adapter/admin/firebase.mjs
+++ b/src/adapter/admin/firebase.mjs
@@ -12,6 +12,6 @@ export function firestore(options) {
       preferRest: options?.server?.preferRest,
     });
   } else {
-    return getFirestore(app);
+    return getFirestore(app, options?.database);
   }
 }

--- a/src/adapter/web/firebase.mjs
+++ b/src/adapter/web/firebase.mjs
@@ -6,5 +6,5 @@ export const firestoreSymbol = Symbol();
 export function firestore(options) {
   const appName = options?.client?.app || options?.app;
   const app = getApp(appName);
-  return getFirestore(app);
+  return getFirestore(app, options?.database);
 }

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -1686,6 +1686,8 @@ export namespace TypesaurusCore {
   export interface Options {
     /** The app name. */
     app?: string;
+    /** The database id */
+    database?: string;
     /** The server options. */
     server?: OptionsServer;
     /** The client options. */


### PR DESCRIPTION
This PR adds the ability to specify the Firestore database ID when initializing Typesaurus. This is useful for projects using multiple databases within a single Firebase project or when connecting to a non-default database.

Changes:

Updated TypesaurusCore.Options interface in `src/types/core.ts` to include the optional database property.

Updated Firestore initialization in admin `src/adapter/admin/firebase.mjs` and web `src/adapter/web/firebase.mjs` adapters to pass the `database Id` to the `getFirestore` function.

Bumped package version to `10.7.1` in `package.json`

Updated `CHANGELOG.md` file 

Usage Example:

```typescript
import { schema } from 'typesaurus'

const db = schema(
  ($) => ({
    users: $.collection<User>()
  }),
  { database: 'my-custom-db-id' }
)
```



@kossnocorp #130 issue